### PR TITLE
#349321

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientgrid/filter/PatientGridFilterUtils.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/filter/PatientGridFilterUtils.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.patientgrid.filter;
 
 import static org.openmrs.module.patientgrid.PatientGridColumn.ColumnDatatype.DATAFILTER_COUNTRY;
+import static org.openmrs.module.patientgrid.PatientGridColumn.ColumnDatatype.ENC_AGE;
 import static org.openmrs.module.patientgrid.PatientGridConstants.DATETIME_FORMAT;
 import static org.openmrs.module.patientgrid.PatientGridConstants.DATE_FORMAT;
 
@@ -60,14 +61,15 @@ public class PatientGridFilterUtils {
 	public static CohortDefinition generateCohortDefinition(PatientGrid patientGrid) {
 		Map<String, CohortDefinition> columnAndCohortDefMap = new HashMap(patientGrid.getColumns().size());
 		for (PatientGridColumn column : patientGrid.getColumns()) {
-			if (!column.getFilters().isEmpty()) {
-				CohortDefinition cohortDef;
+			CohortDefinition cohortDef = null;
+			if (ENC_AGE.equals(column.getDatatype())) {
+				//for age, we will always create a range cohort definition as it's used to filter on the encounter type
+				cohortDef = createAgeRangeCohortDefinition(column);
+			} else if (!column.getFilters().isEmpty()) {
+				
 				switch (column.getDatatype()) {
 					case GENDER:
 						cohortDef = createGenderCohortDefinition(column);
-						break;
-					case ENC_AGE:
-						cohortDef = createAgeRangeCohortDefinition(column);
 						break;
 					case OBS:
 						cohortDef = createObsCohortDefinition(column);
@@ -79,7 +81,8 @@ public class PatientGridFilterUtils {
 					default:
 						throw new APIException("Don't know how to filter data for column type: " + column.getDatatype());
 				}
-				
+			}
+			if (cohortDef != null) {
 				columnAndCohortDefMap.put(column.getName(), cohortDef);
 			}
 		}

--- a/api/src/main/java/org/openmrs/module/patientgrid/filter/definition/AgeRangeAtLatestEncounterCohortDefinition.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/filter/definition/AgeRangeAtLatestEncounterCohortDefinition.java
@@ -38,7 +38,14 @@ public class AgeRangeAtLatestEncounterCohortDefinition extends BaseCohortDefinit
 	}
 	
 	/**
-	 * Gets the ageRanges
+	 * @return true if all ages will be accepted
+	 */
+	public boolean isAllAgesAccepted() {
+		return ageRanges == null || ageRanges.isEmpty();
+	}
+	
+	/**
+	 * Gets the ageRanges. If no age ranges, it means that all ages will be accepted
 	 *
 	 * @return the ageRanges
 	 */

--- a/api/src/test/java/org/openmrs/module/patientgrid/download/DownloadUtilsContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/patientgrid/download/DownloadUtilsContextSensitiveTest.java
@@ -52,7 +52,7 @@ public class DownloadUtilsContextSensitiveTest extends BaseModuleContextSensitiv
 		
 		SimpleDataSet dataset = DownloadUtils.evaluate(patientGrid);
 		
-		assertEquals(3, dataset.getRows().size());
+		assertEquals(4, dataset.getRows().size());
 		Patient patient = ps.getPatient(2);
 		assertEquals(patient.getUuid(), dataset.getColumnValue(patient.getId(), COLUMN_UUID));
 		assertEquals(patient.getPersonName().getFullName(), dataset.getColumnValue(patient.getId(), "name"));
@@ -135,6 +135,21 @@ public class DownloadUtilsContextSensitiveTest extends BaseModuleContextSensitiv
 		encounters = (List) dataset.getColumnValue(patient.getId(), followUpEncTypeUuid);
 		assertEquals(1, encounters.size());
 		assertTrue(encounters.get(0).isEmpty());
+		
+		// a patient with no values
+		patient = ps.getPatient(8);
+		assertEquals(patient.getUuid(), dataset.getColumnValue(patient.getId(), COLUMN_UUID));
+		assertEquals(patient.getPersonName().getFullName(), dataset.getColumnValue(patient.getId(), "name"));
+		assertEquals(patient.getGender(), dataset.getColumnValue(patient.getId(), "gender"));
+		assertNull(dataset.getColumnValue(patient.getId(), "ageAtInitial"));
+		assertNull(dataset.getColumnValue(patient.getId(), "ageCategory"));
+		location = locationService.getLocation(4000);
+		assertEquals(location.getName(), dataset.getColumnValue(patient.getId(), "structure"));
+		assertEquals(location.getCountry(), dataset.getColumnValue(patient.getId(), "country"));
+		encounters = (List) dataset.getColumnValue(patient.getId(), initialEncTypeUuid);
+		assertEquals(1, encounters.size());
+		columnUuidAndObsMap = encounters.get(0);
+		assertTrue(columnUuidAndObsMap.isEmpty());
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/patientgrid/filter/PatientGridFilterUtilsContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/patientgrid/filter/PatientGridFilterUtilsContextSensitiveTest.java
@@ -65,7 +65,7 @@ public class PatientGridFilterUtilsContextSensitiveTest extends BaseModuleContex
 	}
 	
 	@Test
-	public void filterPatients_shouldReturnNullIfNoFiltersAreFound() throws Exception {
+	public void filterPatients_shouldNotReturnNullIfNoFiltersAreFoundAsFilterOnEncounterTypeByDefault() throws Exception {
 		PatientGrid patientGrid = service.getPatientGrid(1);
 		boolean hasFilteredColumns = false;
 		for (PatientGridColumn column : patientGrid.getColumns()) {
@@ -76,7 +76,8 @@ public class PatientGridFilterUtilsContextSensitiveTest extends BaseModuleContex
 		}
 		assertFalse(hasFilteredColumns);
 		
-		assertNull(PatientGridFilterUtils.filterPatients(patientGrid, null));
+		Cohort cohort = PatientGridFilterUtils.filterPatients(patientGrid, null);
+		assertEquals(4, cohort.getMemberships().size());
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/module/patientgrid/web/rest/v1_0/controller/PatientGridDownloadControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/patientgrid/web/rest/v1_0/controller/PatientGridDownloadControllerTest.java
@@ -35,7 +35,7 @@ public class PatientGridDownloadControllerTest extends BasePatientGridRestContro
 		assertEquals(getAllCount(), Util.getResultsSize(result));
 		Map downloadReport = (Map) ((List) Util.getByPath(result, "results")).get(0);
 		assertEquals(GRID_UUID, Util.getByPath(downloadReport, new String[] { "patientGrid", "uuid" }));
-		assertEquals(3, ((List) Util.getByPath(downloadReport, "report")).size());
+		assertEquals(4, ((List) Util.getByPath(downloadReport, "report")).size());
 	}
 	
 	@Override

--- a/omod/src/test/java/org/openmrs/module/patientgrid/web/rest/v1_0/controller/PatientGridReportControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/patientgrid/web/rest/v1_0/controller/PatientGridReportControllerTest.java
@@ -55,7 +55,7 @@ public class PatientGridReportControllerTest extends BasePatientGridRestControll
 		assertEquals(getAllCount(), Util.getResultsSize(result));
 		Map report = (Map) ((List) Util.getByPath(result, "results")).get(0);
 		assertEquals(GRID_UUID, Util.getByPath(report, new String[] { "patientGrid", "uuid" }));
-		assertEquals(3, ((List) Util.getByPath(report, "report")).size());
+		assertEquals(4, ((List) Util.getByPath(report, "report")).size());
 	}
 	
 	@Test


### PR DESCRIPTION
Fix issue in case of no filter on Age Category
The issue: if the user doesn't select an age category in the filters, all patients were displayed even with those with no forms/visits

The expected behavior: display only patients having the selected forms filled even if no age category is selected.