### PR TITLE
add limit to number of records in a patient grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ You will have to generate a token from a Github package (with read access to pac
 
 # Global Properties
 
+## Row count limit
+
+**Property Name** `patientgrid.rowsLimit`
+
+Specifies the limit of number of records in a patient grid.
+By default, the limit will be set to 100.
+
 ## Period range
 
 **Property Name** `patientgrid.defaultPeriod`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You will have to generate a token from a Github package (with read access to pac
 
 **Property Name** `patientgrid.rowsLimit`
 
-Specifies the limit of number of records in a patient grid.
+Specifies the limit of maximum number of records in a patient grid.
 By default, the limit will be set to 100.
 
 ## Period range

--- a/api/src/main/java/org/openmrs/module/patientgrid/PatientGridConstants.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/PatientGridConstants.java
@@ -49,6 +49,6 @@ public class PatientGridConstants {
 	
 	public static final PatientGridObsConverter OBS_CONVERTER = new PatientGridObsConverter();
 	
-	public static int GP_ROWS_COUNT_LIMIT = 100;
+	public static final String GP_ROWS_COUNT_LIMIT = MODULE_ID + ".rowsLimit";
 	
 }

--- a/api/src/main/java/org/openmrs/module/patientgrid/PatientGridConstants.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/PatientGridConstants.java
@@ -49,4 +49,6 @@ public class PatientGridConstants {
 	
 	public static final PatientGridObsConverter OBS_CONVERTER = new PatientGridObsConverter();
 	
+	public static int GP_ROWS_COUNT_LIMIT = 100;
+	
 }

--- a/api/src/main/java/org/openmrs/module/patientgrid/api/impl/PatientGridServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/api/impl/PatientGridServiceImpl.java
@@ -137,7 +137,7 @@ public class PatientGridServiceImpl extends BaseOpenmrsService implements Patien
 			
 			context.setBaseCohort(cohort);
 			int limit = 100;
-			String rowLimit = Context.getAdministrationService().getGlobalProperty("rowsLimit");
+			String rowLimit = Context.getAdministrationService().getGlobalProperty(GP_ROWS_COUNT_LIMIT);
 			if (StringUtils.isNotBlank(rowLimit)) {
 				try {
 					limit = Integer.parseInt(rowLimit);

--- a/api/src/main/java/org/openmrs/module/patientgrid/api/impl/PatientGridServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/api/impl/PatientGridServiceImpl.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.openmrs.module.patientgrid.PatientGridConstants.GP_MAX_CACHE_FILE_AGE;
 import static org.openmrs.module.patientgrid.PatientGridConstants.GP_ROWS_COUNT_LIMIT;
 
 @Transactional(readOnly = true)

--- a/api/src/main/java/org/openmrs/module/patientgrid/api/impl/PatientGridServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/api/impl/PatientGridServiceImpl.java
@@ -133,6 +133,7 @@ public class PatientGridServiceImpl extends BaseOpenmrsService implements Patien
 			}
 			
 			context.setBaseCohort(cohort);
+			context.setLimit(PatientGridConstants.GP_ROWS_COUNT_LIMIT);
 			SimpleDataSet ds;
 			//if the cohort is empty -> do nothing
 			if (cohort.isEmpty()) {
@@ -142,8 +143,12 @@ public class PatientGridServiceImpl extends BaseOpenmrsService implements Patien
 			}
 			ExtendedDataSet extendedDataSet = new ExtendedDataSet(ds,
 			        cohortWithPeriod == null ? null : cohortWithPeriod.getDateRange());
-			//go on configuration here.
-			
+
+			extendedDataSet.setRowsCountLimit(PatientGridConstants.GP_ROWS_COUNT_LIMIT);
+			extendedDataSet.setInitialRowsCount(cohort.activeMembershipSize());
+			if (PatientGridConstants.GP_ROWS_COUNT_LIMIT < cohort.activeMembershipSize()) {
+				extendedDataSet.setTruncated(true);
+			}
 			stopWatch.stop();
 			
 			log.debug("Report for patient grid {} completed in {}", patientGrid, stopWatch.toString());

--- a/api/src/test/java/org/openmrs/module/patientgrid/api/PatientGridServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/patientgrid/api/PatientGridServiceTest.java
@@ -243,10 +243,15 @@ public class PatientGridServiceTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldReturnTwoRecordsInAGridWhenLimitIsTwo() {
+		//setup
 		final String limit = "2";
 		when(mockAdminService.getGlobalProperty(GP_ROWS_COUNT_LIMIT)).thenReturn(limit);
+
+		//action
 		PatientGrid patientGrid = service.getPatientGrid(1);
 		ExtendedDataSet dataSet = service.evaluate(patientGrid);
+
+		//assert
 		assertEquals(2, dataSet.getSimpleDataSet().getRows().size());
 		assertEquals(2, dataSet.getRowsCountLimit());
 		assertEquals(3, dataSet.getInitialRowsCount());
@@ -254,9 +259,14 @@ public class PatientGridServiceTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldReturnOneRecordInAGridWhenLimitIsOne() {
+		//setup
 		final String limit = "1";
 		when(mockAdminService.getGlobalProperty(GP_ROWS_COUNT_LIMIT)).thenReturn(limit);
+
+		//action
 		PatientGrid patientGrid = service.getPatientGrid(1);
+
+		//assert
 		ExtendedDataSet dataSet = service.evaluate(patientGrid);
 		assertEquals(1, dataSet.getSimpleDataSet().getRows().size());
 		assertEquals(1, dataSet.getRowsCountLimit());

--- a/api/src/test/java/org/openmrs/module/patientgrid/api/PatientGridServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/patientgrid/api/PatientGridServiceTest.java
@@ -246,8 +246,10 @@ public class PatientGridServiceTest extends BaseModuleContextSensitiveTest {
 		final String limit = "2";
 		when(mockAdminService.getGlobalProperty(GP_ROWS_COUNT_LIMIT)).thenReturn(limit);
 		PatientGrid patientGrid = service.getPatientGrid(1);
-		SimpleDataSet dataSet = service.evaluate(patientGrid).getSimpleDataSet();
-		assertEquals(2, dataSet.getRows().size());
+		ExtendedDataSet dataSet = service.evaluate(patientGrid);
+		assertEquals(2, dataSet.getSimpleDataSet().getRows().size());
+		assertEquals(2, dataSet.getRowsCountLimit());
+		assertEquals(3, dataSet.getInitialRowsCount());
 	}
 	
 	@Test
@@ -255,8 +257,10 @@ public class PatientGridServiceTest extends BaseModuleContextSensitiveTest {
 		final String limit = "1";
 		when(mockAdminService.getGlobalProperty(GP_ROWS_COUNT_LIMIT)).thenReturn(limit);
 		PatientGrid patientGrid = service.getPatientGrid(1);
-		SimpleDataSet dataSet = service.evaluate(patientGrid).getSimpleDataSet();
-		assertEquals(1, dataSet.getRows().size());
+		ExtendedDataSet dataSet = service.evaluate(patientGrid);
+		assertEquals(1, dataSet.getSimpleDataSet().getRows().size());
+		assertEquals(1, dataSet.getRowsCountLimit());
+		assertEquals(3, dataSet.getInitialRowsCount());
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/patientgrid/api/PatientGridServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/patientgrid/api/PatientGridServiceTest.java
@@ -1,24 +1,8 @@
 package org.openmrs.module.patientgrid.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
-import static org.openmrs.module.patientgrid.PatientGridConstants.*;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.openmrs.Cohort;
@@ -35,7 +19,6 @@ import org.openmrs.module.patientgrid.ExtendedDataSet;
 import org.openmrs.module.patientgrid.PatientGrid;
 import org.openmrs.module.patientgrid.PatientGridColumn;
 import org.openmrs.module.patientgrid.PatientGridColumn.ColumnDatatype;
-import org.openmrs.module.patientgrid.PatientGridConstants;
 import org.openmrs.module.patientgrid.period.DateRange;
 import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.service.CohortDefinitionService;
@@ -46,15 +29,19 @@ import org.openmrs.module.reporting.dataset.definition.DataSetDefinition;
 import org.openmrs.module.reporting.dataset.definition.service.DataSetDefinitionService;
 import org.openmrs.module.reporting.evaluation.EvaluationContext;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
-import org.openmrs.util.OpenmrsUtil;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.openmrs.module.patientgrid.PatientGridConstants.*;
 
 public class PatientGridServiceTest extends BaseModuleContextSensitiveTest {
 	

--- a/api/src/test/java/org/openmrs/module/patientgrid/api/PatientGridServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/patientgrid/api/PatientGridServiceTest.java
@@ -244,12 +244,10 @@ public class PatientGridServiceTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void shouldReturnTwoRecordsInAGridWhenLimitIsTwo() {
 		//setup
-		final String limit = "2";
-		when(mockAdminService.getGlobalProperty(GP_ROWS_COUNT_LIMIT)).thenReturn(limit);
+		when(mockAdminService.getGlobalProperty(GP_ROWS_COUNT_LIMIT)).thenReturn("2");
 
 		//action
-		PatientGrid patientGrid = service.getPatientGrid(1);
-		ExtendedDataSet dataSet = service.evaluate(patientGrid);
+		ExtendedDataSet dataSet = service.evaluate(service.getPatientGrid(1));
 
 		//assert
 		assertEquals(2, dataSet.getSimpleDataSet().getRows().size());
@@ -260,14 +258,12 @@ public class PatientGridServiceTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void shouldReturnOneRecordInAGridWhenLimitIsOne() {
 		//setup
-		final String limit = "1";
-		when(mockAdminService.getGlobalProperty(GP_ROWS_COUNT_LIMIT)).thenReturn(limit);
+		when(mockAdminService.getGlobalProperty(GP_ROWS_COUNT_LIMIT)).thenReturn("1");
 
 		//action
-		PatientGrid patientGrid = service.getPatientGrid(1);
+	        ExtendedDataSet dataSet = service.evaluate(service.getPatientGrid(1));
 
 		//assert
-		ExtendedDataSet dataSet = service.evaluate(patientGrid);
 		assertEquals(1, dataSet.getSimpleDataSet().getRows().size());
 		assertEquals(1, dataSet.getRowsCountLimit());
 		assertEquals(3, dataSet.getInitialRowsCount());

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -60,6 +60,12 @@
             Specifies the max age ( in hour) cache files should be kept on disk
         </description>
     </globalProperty>
+    <globalProperty>
+        <property>${project.parent.artifactId}.rowsLimit</property>
+        <description>
+            Specifies the number of records in a patient grid.
+        </description>
+    </globalProperty>
 
 </module>
 


### PR DESCRIPTION
keeping the limit to 100 for now