### PR TITLE
(feat) Remove ObsGroup Nullability in Filter for Fetching Obs inside ObsGroup

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientgrid/PatientGridUtils.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/PatientGridUtils.java
@@ -216,7 +216,7 @@ public class PatientGridUtils {
 		if (obs != null && concept != null) {
 			int conceptHashcode = concept.hashCode();
 			List<Obs> matches = obs.stream()
-			        .filter(o -> !o.getVoided() && o.getObsGroup() == null && o.getConcept().hashCode() == conceptHashcode
+			        .filter(o -> !o.getVoided() && o.getConcept().hashCode() == conceptHashcode
 			                && o.getConcept().equals(concept) && !o.hasGroupMembers(true))
 			        .collect(Collectors.toList());
 			

--- a/api/src/test/java/org/openmrs/module/patientgrid/PatientGridUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/patientgrid/PatientGridUtilsTest.java
@@ -187,18 +187,22 @@ public class PatientGridUtilsTest {
 	}
 	
 	@Test
-	public void getObsByConcept_shouldExcludeObsGroupings() {
+	public void getObsByConcept_shouldNotExcludeObsGroupings() {
 		final String conceptUuid = "test-uuid";
+		final String groupConceptUuid = "test-group-uuid";
 		Encounter encounter = new Encounter();
 		Concept obsConcept = new Concept();
+		Concept obsGroupConcept = new Concept();
 		obsConcept.setUuid(conceptUuid);
+		obsGroupConcept.setUuid(groupConceptUuid);
 		Obs obs = new Obs();
+		Obs obsGroup = new Obs();
 		obs.setConcept(obsConcept);
-		obs.addGroupMember(new Obs());
+		obsGroup.setConcept(obsGroupConcept);
+		obsGroup.addGroupMember(obs);
 		encounter.addObs(obs);
-		Concept concept = new Concept();
-		concept.setUuid(conceptUuid);
-		assertNull(PatientGridUtils.getObsByConcept(encounter, concept));
+		encounter.addObs(obsGroup);
+		assertEquals(obs, PatientGridUtils.getObsByConcept(encounter, obsConcept));
 	}
 	
 	@Test


### PR DESCRIPTION
### **Description:** ###
This pull request addresses the issue where the ObsGroup nullability in the filter was preventing the retrieval of Obs inside ObsGroup structures. By removing the nullability constraint, the system can now successfully fetch Obs that are nested within ObsGroup, allowing for more accurate data retrieval and analysis.

### **Changes Made:** ###

Removed ObsGroup nullability constraint: The filter responsible for fetching Obs has been modified to remove the nullability restriction on ObsGroup. Previously, this constraint prevented the retrieval of Obs that were encapsulated within ObsGroup structures. With this update, the system can now fetch Obs at any level within ObsGroup, ensuring a more comprehensive data retrieval process.
Benefits:

Complete data retrieval: By removing the ObsGroup nullability constraint, the system can retrieve all relevant Obs, regardless of their position within ObsGroup structures. This enables users to access and analyze nested Obs data accurately, leading to more robust and comprehensive data insights.