### PR TITLE
(feat) Enable backend date filters to match a single date

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientgrid/period/DateRange.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/period/DateRange.java
@@ -35,4 +35,11 @@ public class DateRange implements Serializable {
 		return fromInServerTz;
 	}
 	
+	public long getTimeRange() {
+		return toInServerTz.getTime() - fromInServerTz.getTime();
+	}
+	
+	public boolean isWiderRangeThan(DateRange other) {
+		return this.getTimeRange() > other.getTimeRange();
+	}
 }


### PR DESCRIPTION
Enhance backend filters to support exact date matching instead of being limited to date ranges.

![image](https://github.com/icrc/openmrs-module-patientgrid/assets/68599335/4f586cb6-5b02-4cb7-a218-36c4ba2c9661)
