### PR TITLE
(fix) Handle concepts reused multiple times on same form

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientgrid/evaluator/ObsForLatestEncounterPatientDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/evaluator/ObsForLatestEncounterPatientDataEvaluator.java
@@ -11,6 +11,7 @@ import org.openmrs.module.patientgrid.function.MostRecentEncounterPerPatientByTy
 import org.openmrs.module.reporting.data.patient.EvaluatedPatientData;
 import org.openmrs.module.reporting.data.patient.definition.PatientDataDefinition;
 import org.openmrs.module.reporting.data.patient.evaluator.PatientDataEvaluator;
+import org.openmrs.module.reporting.dataset.column.definition.RowPerObjectColumnDefinition;
 import org.openmrs.module.reporting.evaluation.EvaluationContext;
 import org.openmrs.module.reporting.evaluation.EvaluationException;
 
@@ -38,7 +39,8 @@ public class ObsForLatestEncounterPatientDataEvaluator implements PatientDataEva
 		Set<Integer> patients = baseCohort == null ? patientIdAndEnc.keySet() : baseCohort.getMemberIds();
 		for (Integer patientId : patients) {
 			Encounter e = (Encounter) patientIdAndEnc.get(patientId);
-			Obs obs = PatientGridUtils.getObsByConcept(e, def.getConcept());
+			Obs obs = PatientGridUtils.getObsByConcept(e, def.getConcept(),
+			    (RowPerObjectColumnDefinition) context.getContextValues().get("columnDefinitions"));
 			if (obs != null) {
 				patientIdAndObs.put(patientId, obs);
 			}


### PR DESCRIPTION
If a concept is reused multiple times within a form, the answer text is now displayed correctly in the corresponding patient grid's column.
For questions with multiple answers, all the answers are now concatenated in the corresponding column cell.