### PR TITLE
(fix) fix for the country filter overlapping the location filter

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientgrid/filter/PatientGridFilterUtils.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/filter/PatientGridFilterUtils.java
@@ -104,13 +104,20 @@ public class PatientGridFilterUtils {
 	}
 
 	public static LocationCohortDefinition extractLocations(PatientGrid patientGrid) {
+		PatientGridColumn columnToUse = null;
 		for (PatientGridColumn column : patientGrid.getColumns()) {
-			if (!column.getFilters().isEmpty()
-			        && (ENC_LOCATION.equals(column.getDatatype()) || ENC_COUNTRY.equals(column.getDatatype()))) {
-				return createLocationCohortDefinition(column, column.getDatatype() == ENC_COUNTRY);
+			if(column.getFilters().isEmpty()){
+				continue;
+			}
+			if(ENC_LOCATION.equals(column.getDatatype())){
+				columnToUse = column;
+				break;
+			}
+			if(ENC_COUNTRY.equals(column.getDatatype())){
+				columnToUse = column;
 			}
 		}
-		return null;
+		return columnToUse != null ? createLocationCohortDefinition(columnToUse, columnToUse.getDatatype() == ENC_COUNTRY) : null;
 	}
 
 	public static boolean canSeeLocations(PatientGrid patientGrid) {


### PR DESCRIPTION
### (fix) Country filter overlapping the location filter.

Resolved an issue where the country filter was overlapping the location filter, causing UI display inconsistencies. The fix ensures proper alignment and separation between the two filters.

With this fix, users can now effectively utilize both the (location) and country filters without encountering any overlapping issues

Thanks,
CC: @icrc-fdeniger 