### PR TITLE
(fix) Properly handle questions nested within obsgroups

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientgrid/download/AllEncountersPatientDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/patientgrid/download/AllEncountersPatientDataEvaluator.java
@@ -43,7 +43,8 @@ public class AllEncountersPatientDataEvaluator implements PatientDataEvaluator {
 			        patientEncs.stream().forEach(encounter -> {
 				        Map<String, Object> columnUuidAndObsMap = new HashMap(obsColumns.size());
 				        obsColumns.stream().forEach(column -> {
-					        Obs obs = PatientGridUtils.getObsByConcept(encounter, column.getConcept());
+					        Obs obs = PatientGridUtils.getObsByConcept(encounter, column.getConcept(),
+					            extractQuestionIdFromColumn(column));
 					        if (obs != null) {
 						        columnUuidAndObsMap.put(column.getUuid(), DataUtil.convertData(obs, OBS_CONVERTER));
 					        }
@@ -67,4 +68,7 @@ public class AllEncountersPatientDataEvaluator implements PatientDataEvaluator {
 		return result;
 	}
 
+	private static String extractQuestionIdFromColumn(ObsPatientGridColumn column) {
+		return column.getName().substring(column.getName().lastIndexOf("--") + 2);
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <openmrsPlatformVersion>2.3.0</openmrsPlatformVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <calculationVersion>1.2</calculationVersion>
-        <reportingVersion>1.14.0</reportingVersion>
+        <reportingVersion>1.26.0</reportingVersion>
         <datafilterVersion>1.2.0</datafilterVersion>
         <webservicesRestVersion>2.27.0</webservicesRestVersion>
         <serializationXstreamVersion>0.2.16</serializationXstreamVersion>


### PR DESCRIPTION
Properly handle questions nested within obs groups by taking into account the form schema question id. This solves a problem causing a patient grid export not to include questions nested inside obs groups.